### PR TITLE
Adds some consistency + fixes a couple of typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,24 +32,23 @@ Thank you for looking :) Good hunting!
 - [DOZ.com](https://www.doz.com) - Plan your digital marketing campaigns and outsource them to marketing pros.
 - [Pipeline](https://www.pipelinedaily.com/#why-use) - Sends curated projects to your inbox weekly. Made by freelancers for freelancers
 - [We Work Remotely](https://weworkremotely.com/) - Find jobs that aren't restricted by commutes or a particular geographic area.
-- [HackHands] (https://hackhands.com) - Live programming help. Get paid per minute, while helping other programmers.
-- [RemoteBase](https://remotebase.io/) - An Open Database of Remote Companies
-- [Freelancer.com](http://www.freelancer.com/) - Freelancer.com is the world's largest freelancing, outsourcing and crowdsourcing marketplace by number of users and projects.
-- [Pilot](https://pilot.co/) - Pilot is a software platform that removes all the pain from contract work. We find work, negotiate contracts, send invoices and chase payments for hundreds of forward-looking engineers and designers around the world.
+- [HackHands](https://hackhands.com) - Live programming help. Get paid per minute, while helping other programmers.
+- [RemoteBase](https://remotebase.io/) - An open database of remote companies
+- [Freelancer.com](http://www.freelancer.com/) - The world's largest freelancing, outsourcing and crowdsourcing marketplace by number of users and projects.
+- [Pilot](https://pilot.co/) - A software platform that removes all the pain from contract work. We find work, negotiate contracts, send invoices and chase payments for hundreds of forward-looking engineers and designers around the world.
 - [Remotely Awesome Jobs](https://www.remotelyawesomejobs.com) - An extensive remote job board aggregator.
-- [X-Team](http://x-team.com) - X-Team provides motivated developers, ready to join your team. We are the most developer-centric company for remote developers, helping them learn and grow like few tech companies have done before. "Work on incredible projects. Unelash your potential. From anywhere."
+- [X-Team](http://x-team.com) - Provides motivated developers, ready to join your team. We are the most developer-centric company for remote developers, helping them learn and grow like few tech companies have done before. "Work on incredible projects. Unelash your potential. From anywhere."
 - [Authentic Jobs](http://www.authenticjobs.com/#onlyremote=1") - Full-time and freelance job opportunities for creatives.
-- [Dribbble Jobs](https://dribbble.com/jobs?utf8=%E2%9C%93&amp;anywhere=true&amp;location=Anywhere")
-  span.description Remote jobs for designers.
+- [Dribbble Jobs](https://dribbble.com/jobs?utf8=%E2%9C%93&amp;anywhere=true&amp;location=Anywhere) - Remote jobs for designers.
 - [Stack Overflow Careers](http://careers.stackoverflow.com/jobs/remote)- Remote jobs for developers.
 - [Angel List Jobs](https://angel.co/jobs#find/f!%7B%22remote%22%3Atrue%7D) - Apply privately to thousands of the best startup jobs.
-- [No Fluff Jobs](https://nofluffjobs.com/#criteria=remote" - Features remote IT jobs in a standardized and detailed way.
-- [ITflow](http://itflow.biz/) - ITflow - The best remote IT jobs.
-- [Jobbox](https://www.jobbox.io/offers?t=&amp;s=featured&amp;r=on) - Jobbox connects the best tech candidates with the best jobs.
+- [No Fluff Jobs](https://nofluffjobs.com/#criteria=remote) - Features remote IT jobs in a standardized and detailed way.
+- [ITflow](http://itflow.biz/) - The best remote IT jobs.
+- [Jobbox](https://www.jobbox.io/offers?t=&amp;s=featured&amp;r=on) - Connects the best tech candidates with the best jobs.
 - [jobsRemotely](https://jobsremotely.com/remote/jobs) - Find jobs that are not restricted to a particular location.
 - [RemoteCoder](https://remotecoder.io/)- The place to find the best remote jobs.
 - [WFH](https://www.wfh.io/) - A job board focusing on remote jobs in the technology space.
-- [Jobmote](http://jobmote.com/) - Jobmote is a directory of IT career opportunities that allow you to work from home.
+- [Jobmote](http://jobmote.com/) - A directory of IT career opportunities that allow you to work from home.
 - [Jobscribe](http://jobscri.be/) - Get a daily email with remote jobs at tech startups.
 - [Remote Digest](http://remotedigest.com/) - Get weekly emails with awesome remote jobs for developers.
 - [Golang Jobs](http://www.golangprojects.com/golang-remote-jobs.html) - Remote jobs for Go/Golang developers.


### PR DESCRIPTION
* There's no need to have a name of the website in the beginning of the description because it's already on its left.
* One typo where Markdown link wasn't properly closed.
* One typo in which the was a space between `[..]` and `(...)` in a Markdown link.
* Removes unnecessary capitalization from one description.
* Removes `span.description` in one of the links for which I presume were added there by copying something over from somewhere.